### PR TITLE
Implement test macros for cljs and improve usage.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ysera "1.4.0"
+(defproject ysera "2.0.0"
   :description "Useful tools for Clojure/ClojureScript"
   :url ""
   :license {}

--- a/project.clj
+++ b/project.clj
@@ -2,6 +2,8 @@
   :description "Useful tools for Clojure/ClojureScript"
   :url ""
   :license {}
-  :dependencies [[org.clojure/clojure "1.10.0"]]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojurescript "1.10.520"]
+                 [net.cgrand/macrovich "0.2.1"]]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/ysera/collections.cljc
+++ b/src/ysera/collections.cljc
@@ -1,5 +1,5 @@
 (ns ysera.collections
-  (:require [ysera.test #?(:clj :refer :cljs :refer-macros) [is is=]]))
+  (:require [ysera.test :refer [is is=]]))
 
 (defn index-of
   "Gets the index of the given element of the collection."

--- a/src/ysera/debug.cljc
+++ b/src/ysera/debug.cljc
@@ -1,12 +1,12 @@
 (ns ysera.debug
   #?(:clj  (:require [net.cgrand.macrovich :as macros])
      :cljs (:require-macros [net.cgrand.macrovich :as macros]
-                            [ysera.debug :refer [dlet printret]])))
+                            [ysera.debug :refer [printlet printreturn]])))
 
 (macros/deftime
 
   ; from http://brownsofa.org/blog/2014/08/03/debugging-in-clojure-tools/
-  (defmacro dlet [bindings & body]
+  (defmacro printlet [bindings & body]
     `(let [~@(mapcat (fn [[n v]]
                        (if (or (vector? n) (map? n))
                          [n v]
@@ -14,7 +14,7 @@
                      (partition 2 bindings))]
        ~@body))
 
-  (defmacro printret
+  (defmacro printreturn
     ([expression] `(let [result# ~expression]
                      (println result#)
                      result#))

--- a/src/ysera/debug.cljc
+++ b/src/ysera/debug.cljc
@@ -1,0 +1,1 @@
+(ns ysera.debug)

--- a/src/ysera/debug.cljc
+++ b/src/ysera/debug.cljc
@@ -1,1 +1,23 @@
-(ns ysera.debug)
+(ns ysera.debug
+  #?(:clj  (:require [net.cgrand.macrovich :as macros])
+     :cljs (:require-macros [net.cgrand.macrovich :as macros]
+                            [ysera.debug :refer [dlet printret]])))
+
+(macros/deftime
+
+  ; from http://brownsofa.org/blog/2014/08/03/debugging-in-clojure-tools/
+  (defmacro dlet [bindings & body]
+    `(let [~@(mapcat (fn [[n v]]
+                       (if (or (vector? n) (map? n))
+                         [n v]
+                         [n v '_ `(println (name '~n) ":" ~v)]))
+                     (partition 2 bindings))]
+       ~@body))
+
+  (defmacro printret
+    ([expression] `(let [result# ~expression]
+                     (println result#)
+                     result#))
+    ([str expression] `(let [result# ~expression]
+                         (println ~str result#)
+                         result#))))

--- a/src/ysera/error.cljc
+++ b/src/ysera/error.cljc
@@ -1,5 +1,5 @@
 (ns ysera.error
-  (:require [ysera.test #?(:clj :refer :cljs :refer-macros) [is error?]]))
+     (:require [ysera.test :refer [error?]]))
 
 (defn error
   "Throws an error with the given messages"

--- a/src/ysera/math.cljc
+++ b/src/ysera/math.cljc
@@ -1,5 +1,5 @@
 (ns ysera.math
-  (:require [ysera.test #?(:clj :refer :cljs :refer-macros) [is=]]))
+  (:require [ysera.test :refer [is=]]))
 
 (defn round
   {:test (fn []

--- a/src/ysera/random.cljc
+++ b/src/ysera/random.cljc
@@ -1,5 +1,5 @@
 (ns ysera.random
-  (:require [ysera.test #?(:clj :refer :cljs :refer-macros) [is= is]]
+  (:require [ysera.test :refer [is= is]]
             [ysera.collections :refer [remove-one]]))
 
 (defn- get-pseudo-random-number

--- a/src/ysera/test.cljc
+++ b/src/ysera/test.cljc
@@ -3,6 +3,7 @@
      :cljs (:require-macros [net.cgrand.macrovich :as macros]
                             [ysera.test :refer [deftest testing is is-not is= error?]])))
 
+(macros/deftime
 
   (defmacro is= [actual expected]
     `(do

--- a/src/ysera/test.cljc
+++ b/src/ysera/test.cljc
@@ -1,16 +1,8 @@
 (ns ysera.test
   #?(:clj  (:require [net.cgrand.macrovich :as macros])
      :cljs (:require-macros [net.cgrand.macrovich :as macros]
-                            []
-                            [ysera.test :refer [deftest
-                                                testing
-                                                is
-                                                is-not
-                                                is=
-                                                error?]])))
+                            [ysera.test :refer [deftest testing is is-not is= error?]])))
 
-
-(macros/deftime
 
   (defmacro is= [actual expected]
     `(do

--- a/src/ysera/test.cljc
+++ b/src/ysera/test.cljc
@@ -1,54 +1,54 @@
 (ns ysera.test
-  #?(:clj (:require [clojure.test])))
+  #?(:clj  (:require [net.cgrand.macrovich :as macros])
+     :cljs (:require-macros [net.cgrand.macrovich :as macros]
+                            []
+                            [ysera.test :refer [deftest
+                                                testing
+                                                is
+                                                is-not
+                                                is=
+                                                error?]])))
 
-(defn cljs-env?
-  "Take the &env from a macro, and tell whether we are expanding into cljs."
-  [env]
-  (boolean (:ns env)))
 
-(defmacro if-cljs
-  "Return then if we are generating cljs code and else for Clojure code.
-   https://groups.google.com/d/msg/clojurescript/iBY5HaQda4A/w1lAQi9_AwsJ"
-  [then else]
-  (if (cljs-env? &env) then else))
+(macros/deftime
 
-(defmacro deftest [name & body]
-  `(if-cljs
-     (println "Not implemented.")
-     (clojure.test/deftest ~name ~@body)))
-
-(defmacro is [form]
-  `(if-cljs
-     (println "Not implemented.")
-     (clojure.test/is ~form)))
-
-(defmacro testing [string body]
-  `(if-cljs
-     (println "Not implemented.")
-     (clojure.test/testing ~string ~body)))
-
-(defmacro is= [actual expected]
-  `(if-cljs
-     (println "Not implemented.")
-     (let [actual# ~actual
-           expected# ~expected
-           equal# (= actual# expected#)]
-       (do
+  (defmacro is= [actual expected]
+    `(do
+       (let [actual# ~actual
+             expected# ~expected
+             equal# (= actual# expected#)]
          (when-not equal#
            (println "Actual:\t\t" actual# "\nExpected:\t" expected#))
-         (clojure.test/is (= actual# expected#))))))
+         (macros/case :clj (clojure.test/is (= actual# expected#))
+                      :cljs (cljs.test/is (= actual# expected#))))))
 
-(defmacro is-not [actual]
-  `(if-cljs
-     (println "Not implemented.")
-     (clojure.test/is (not ~actual))))
+  (defmacro deftest [name & body]
+    `(do
+       (macros/case :clj (clojure.test/deftest ~name ~@body)
+                    :cljs (cljs.test/deftest ~name ~@body))))
+  (defmacro testing [string body]
+    `(do
+       (macros/case :clj (clojure.test/testing ~string ~body)
+                    :cljs (cljs.test/testing ~string ~body))))
 
-(defmacro error? [actual]
-  `(if-cljs
-     (println "Not implemented.")
-     (try (do
-            ~actual
-            (println "An error was expected.")
-            (clojure.test/is false))
-          (catch Exception e#
-            (clojure.test/is true)))))
+  (defmacro is [form]
+    `(do
+       (macros/case :clj (clojure.test/is ~form)
+                    :cljs (cljs.test/is ~form))))
+
+  (defmacro is-not [form]
+    `(do
+       (macros/case :clj (clojure.test/is (not ~form))
+                    :cljs (cljs.test/is (not ~form)))))
+
+  (defmacro error? [actual]
+    `(do ~(macros/case :clj `(try (do ~actual
+                                      (println "An error was expected.")
+                                      (clojure.test/is false ~(str "An error was expected:" actual)))
+                                  (catch Exception e#
+                                    (clojure.test/is true)))
+                       :cljs `(try (do ~actual
+                                       (println "An error was expected.")
+                                       (cljs.test/is false ~(str "An error was expected: " actual)))
+                                   (catch js/Object e#
+                                     (cljs.test/is true)))))))

--- a/test/ysera/test_test.clj
+++ b/test/ysera/test_test.clj
@@ -1,26 +1,12 @@
 (ns ysera.test-test
   (:require [ysera.test]
+            [ysera.error]
             [clojure.test]))
 
-(clojure.test/deftest
- similarity
- (clojure.test/is (= (macroexpand '(clojure.test/is (= 1 1)))
-                     (macroexpand '(ysera.test/is (= 1 1)))))
- (clojure.test/is (= (macroexpand '(clojure.test/testing "foo" (= 1 1)))
-                     (macroexpand '(ysera.test/testing "foo" (= 1 1)))))
- (clojure.test/is (= (macroexpand '(clojure.test/is (clojure.core/not (= 2 1))))
-                     (macroexpand '(ysera.test/is-not (= 2 1)))))
- (clojure.test/is (= (macroexpand '(clojure.test/deftest
-                                    name
-                                    (clojure.core/is (= 1 1))
-                                    (clojure.core/is (= 2 2))))
-                     (macroexpand '(ysera.test/deftest
-                                     name
-                                     (clojure.core/is (= 1 1))
-                                     (clojure.core/is (= 2 2)))))))
 
 (clojure.test/deftest equals-1-1
   (ysera.test/is (= 1 1))
   (ysera.test/testing "that 1 equals 1" (= 1 1))
+  (ysera.test/error? (ysera.error/error "an error!"))
   (ysera.test/is= 1 1)
   (ysera.test/is-not (= 1 2)))


### PR DESCRIPTION
Make it possible to use macros from cljs using only :require, in other words no different from clj.

Using https://github.com/cgrand/macrovich helper macros.

Inspiration from https://clojureverse.org/t/how-to-define-and-use-a-macro-in-both-clj-and-cljs/2896.