### PR TITLE
Return 0 as value when supplying 0 as max in get-random-int

### DIFF
--- a/src/ysera/random.cljc
+++ b/src/ysera/random.cljc
@@ -16,9 +16,13 @@
            (is= (get-random-int 1 1)
                 [35651602 0])
            (is= (get-random-int 35651602 12)
-                [1130298060341683 10]))}
+                [1130298060341683 10])
+           (is= (get-random-int 35651602 0)
+                [1130298060341683 0]))}
   [seed max]
-  [(get-pseudo-random-number seed) (mod seed max)])
+  (case max
+    0 [(get-pseudo-random-number seed) 0]
+    [(get-pseudo-random-number seed) (mod seed max)]))
 
 (defn random-nth
   "Returns a new seed and a random element of the collection."


### PR DESCRIPTION
## Issue
Current behaviour of (get-random-int {seed} 0) returns a divide by zero error (see below):
![div0](https://user-images.githubusercontent.com/43146567/143502964-a99ca434-ef9d-4d70-b0bc-e983d0afb11d.PNG)

## Proposed solution
The proposed solution is to default the random integer to 0 when this occurs, but still return a new seed value.

## Justification
This is the behaviour of the built-in [rand-int](https://clojuredocs.org/clojure.core/rand-int) function & it resonates with the default behaviour most would expect from supplying 0 as the max value.