### PR TITLE
Add match macro

### DIFF
--- a/src/ysera/test.cljc
+++ b/src/ysera/test.cljc
@@ -26,6 +26,22 @@
          (macros/case :clj (clojure.test/is (= actual# expected#))
                       :cljs (cljs.test/is (= actual# expected#))))))
 
+
+  (defmacro match= [actual expected]
+    `(do
+       (let [actual# ~actual
+             expected# ~expected
+             mismatches# (find-mismatches actual# expected#)
+             equal# (empty? mismatches#)]
+         (when-not equal#
+           (println "Mismatches found:")
+           (doseq [mismatch# mismatches#]
+             (println " - Key:" (:key mismatch#)
+                      "\n   Actual:  \t" (:actual mismatch#)
+                      "\n   Expected:\t" (:expected mismatch#))))
+         (macros/case :clj (clojure.test/is equal#)
+                      :cljs (cljs.test/is equal#)))))
+
   (defmacro deftest [name & body]
     `(do
        (macros/case :clj (clojure.test/deftest ~name ~@body)
@@ -57,3 +73,16 @@
                                        (cljs.test/is false ~(str "An error was expected: " actual)))
                                    (catch js/Object e#
                                      (cljs.test/is true)))))))
+
+
+(defn find-mismatches
+  "Finds keys in expected that are not equal to the corresponding keys in actual."
+  [actual expected]
+  (reduce (fn [acc key]
+            (let [actual-val (get actual key)
+                  expected-val (get expected key)]
+              (if (= actual-val expected-val)
+                acc
+                (conj acc {:key key, :actual actual-val, :expected expected-val}))))
+          []
+          (keys expected)))

--- a/test/ysera/client_test.clj
+++ b/test/ysera/client_test.clj
@@ -1,5 +1,5 @@
 (ns ysera.client-test
-  (:require [ysera.test :refer [deftest error? is is-not is=]]
+  (:require [ysera.test :refer [deftest error? is is-not is= match=]]
             [ysera.error :refer [error]]))
 
 
@@ -7,4 +7,5 @@
   (is (= 1 1))
   (error? (error "an error!"))
   (is= 1 1)
-  (is-not (= 1 2)))
+  (is-not (= 1 2))
+  (match= {:a 1 :b 2} {:b 2}))

--- a/test/ysera/test_test.clj
+++ b/test/ysera/test_test.clj
@@ -9,4 +9,5 @@
     (ysera.test/testing "that 1 equals 1" (= 1 1))
     (ysera.test/error? (ysera.error/error "an error!"))
     (ysera.test/is= 1 1)
-    (ysera.test/is-not (= 1 2))))
+    (ysera.test/is-not (= 1 2))
+    (ysera.test/match= {:a 1 :b 2} {:b 2})))


### PR DESCRIPTION
Thought that this may be useful. 

### Use case

Matching that a subset of keys are equal to a value. This is a common testing idiom in Elixir which I am used to :)

```clojure
(match= {:a 1 :b 2 :c 3} {:a 1}) // ok
(match= {:a 1 :b 2 :c 3} {:a 2}) // error
(match= {:a 1 :b 2 :c 3} {:d 1}) // error
```

Also writes a nice-ish error message like:

```clojure
; Mismatches found:
;  - Key: :a 
;    Actual:  	 1 
;    Expected:	 2
; 
; FAIL in () (NO_SOURCE_FILE:554)
; expected: equal__8184__auto__
;   actual: false
```

I am a Clojure newbie so let me know if there is a better/more idiomatic way of doing this!